### PR TITLE
Fix: 방문한 Todo 중복 저장 방지

### DIFF
--- a/src/main/kotlin/com/umin/todoapp/domain/todo/repository/TodoRedisRepository.kt
+++ b/src/main/kotlin/com/umin/todoapp/domain/todo/repository/TodoRedisRepository.kt
@@ -13,7 +13,10 @@ class TodoRedisRepository(
     fun saveVisitedTodo(userId: Long, todoId: Long) {
 
         val key = userId.toString()
-        redisTemplate.opsForList().leftPush(key, todoId.toString())
+        val value = todoId.toString()
+
+        redisTemplate.opsForList().remove(key, 0, value)
+        redisTemplate.opsForList().leftPush(key, value)
 
         if (redisTemplate.opsForList().size(key)!! > recentlyVisitedSize) {
             redisTemplate.opsForList().rightPop(key)
@@ -22,7 +25,7 @@ class TodoRedisRepository(
 
     fun getVisitedTodoIdList(userId: Long): List<Long>? {
 
-        return redisTemplate.opsForList().range(userId.toString(), 0, recentlyVisitedSize)
+        return redisTemplate.opsForList().range(userId.toString(), 0, -1)
             ?.map { it.toLong() }
     }
 

--- a/src/main/kotlin/com/umin/todoapp/domain/todo/service/TodoService.kt
+++ b/src/main/kotlin/com/umin/todoapp/domain/todo/service/TodoService.kt
@@ -16,7 +16,7 @@ interface TodoService {
         request: TodoSearchRequest
     ): TodoPageResponse
 
-    fun getVisitedTodoList(userId: Long): List<TodoResponse>
+    fun getVisitedTodoList(userId: Long): List<TodoResponse>?
 
     fun getTodoById(todoId: Long, userId: Long): TodoWithCommentsResponse
 

--- a/src/main/kotlin/com/umin/todoapp/domain/todo/service/TodoServiceImpl.kt
+++ b/src/main/kotlin/com/umin/todoapp/domain/todo/service/TodoServiceImpl.kt
@@ -51,11 +51,11 @@ class TodoServiceImpl(
         return todoRepository.getPaginatedTodoList(pageNumber, pageSize, sort, request)
     }
 
-    override fun getVisitedTodoList(userId: Long): List<TodoResponse> {
+    override fun getVisitedTodoList(userId: Long): List<TodoResponse>? {
 
-        return todoRedisRepository.getVisitedTodoIdList(userId).let { ids ->
-            todoRepository.getTodoListByIds(ids).map { TodoResponse.from(it) }
-        }
+        return todoRedisRepository.getVisitedTodoIdList(userId)
+            ?.map { todoId -> todoRepository.findById(todoId) ?: throw ModelNotFoundException("Todo", todoId) }
+            ?.map { TodoResponse.from(it) }
     }
 
     override fun getTodoById(todoId: Long, userId: Long): TodoWithCommentsResponse {

--- a/src/main/kotlin/com/umin/todoapp/domain/todo/service/TodoServiceImpl.kt
+++ b/src/main/kotlin/com/umin/todoapp/domain/todo/service/TodoServiceImpl.kt
@@ -53,9 +53,11 @@ class TodoServiceImpl(
 
     override fun getVisitedTodoList(userId: Long): List<TodoResponse>? {
 
-        return todoRedisRepository.getVisitedTodoIdList(userId)
-            ?.map { todoId -> todoRepository.findById(todoId) ?: throw ModelNotFoundException("Todo", todoId) }
-            ?.map { TodoResponse.from(it) }
+        return todoRedisRepository.getVisitedTodoIdList(userId)?.let { todoIds ->
+            val todoList = todoRepository.getTodoListByIds(todoIds).map { TodoResponse.from(it) }
+
+            todoIds.map { todoId -> todoList.first { it.id == todoId } }
+        }
     }
 
     override fun getTodoById(todoId: Long, userId: Long): TodoWithCommentsResponse {

--- a/src/main/kotlin/com/umin/todoapp/infra/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/umin/todoapp/infra/redis/RedisConfig.kt
@@ -20,10 +20,10 @@ class RedisConfig(
     }
 
     @Bean
-    fun redisTemplate(): RedisTemplate<String, String> {
+    fun redisTemplate(redisConnectionFactory: RedisConnectionFactory): RedisTemplate<String, String> {
 
         val redisTemplate = RedisTemplate<String, String>()
-        redisTemplate.connectionFactory = redisConnectionFactory()
+        redisTemplate.connectionFactory = redisConnectionFactory
 
         redisTemplate.keySerializer = StringRedisSerializer()
         redisTemplate.valueSerializer = StringRedisSerializer()


### PR DESCRIPTION
## 작업 내용
- 방문한 Todo 저장 시 이미 존재하면 제거한 뒤 저장
- 방문한 Todo 조회 시 id 목록으로 한꺼번에 조회