### PR TITLE
Test: Todo Repository 목록 pagination 조회

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,9 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
     testImplementation("io.mockk:mockk:$mockkVersion")
+    testImplementation("com.h2database:h2")
 
     runtimeOnly("com.mysql:mysql-connector-j")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")

--- a/src/main/kotlin/com/umin/todoapp/domain/todo/controller/TodoController.kt
+++ b/src/main/kotlin/com/umin/todoapp/domain/todo/controller/TodoController.kt
@@ -48,7 +48,7 @@ class TodoController(
         @RequestParam(defaultValue = "1") pageNumber: Int,
         @RequestParam(defaultValue = "5") pageSize: Int,
         @RequestParam(required = false) sort: String?,
-        request: TodoSearchRequest
+        request: TodoSearchRequest?
     ): ResponseEntity<TodoPageResponse> {
         return ResponseEntity
             .status(HttpStatus.OK)

--- a/src/main/kotlin/com/umin/todoapp/domain/todo/repository/ITodoRepository.kt
+++ b/src/main/kotlin/com/umin/todoapp/domain/todo/repository/ITodoRepository.kt
@@ -10,7 +10,7 @@ interface ITodoRepository {
 
     fun getTodoList(sort: String?, writer: String?): List<Todo>
 
-    fun getPaginatedTodoList(pageNumber: Int, pageSize: Int, sort: String?, request: TodoSearchRequest): TodoPageResponse
+    fun getPaginatedTodoList(pageNumber: Int, pageSize: Int, sort: String?, request: TodoSearchRequest?): TodoPageResponse
 
     fun getTodoListByIds(ids: List<Long>?): List<Todo>
 

--- a/src/main/kotlin/com/umin/todoapp/domain/todo/repository/TodoRepositoryImpl.kt
+++ b/src/main/kotlin/com/umin/todoapp/domain/todo/repository/TodoRepositoryImpl.kt
@@ -43,12 +43,12 @@ class TodoRepositoryImpl(
         return query.fetch()
     }
 
-    override fun getPaginatedTodoList(pageNumber: Int, pageSize: Int, sort: String?, request: TodoSearchRequest): TodoPageResponse {
+    override fun getPaginatedTodoList(pageNumber: Int, pageSize: Int, sort: String?, request: TodoSearchRequest?): TodoPageResponse {
 
         val query = queryFactory.select(todo)
             .from(todo)
             .leftJoin(todo.user, user).fetchJoin()
-            .where(allCondition(request))
+            .where(request?.let { allCondition(it) })
 
         val totalPages = ceil(query.fetch().size / pageSize.toDouble()).toInt()
 

--- a/src/main/kotlin/com/umin/todoapp/domain/todo/service/TodoService.kt
+++ b/src/main/kotlin/com/umin/todoapp/domain/todo/service/TodoService.kt
@@ -13,7 +13,7 @@ interface TodoService {
         pageNumber: Int,
         pageSize: Int,
         sort: String?,
-        request: TodoSearchRequest
+        request: TodoSearchRequest?
     ): TodoPageResponse
 
     fun getVisitedTodoList(userId: Long): List<TodoResponse>?

--- a/src/main/kotlin/com/umin/todoapp/domain/todo/service/TodoServiceImpl.kt
+++ b/src/main/kotlin/com/umin/todoapp/domain/todo/service/TodoServiceImpl.kt
@@ -45,7 +45,7 @@ class TodoServiceImpl(
         pageNumber: Int,
         pageSize: Int,
         sort: String?,
-        request: TodoSearchRequest
+        request: TodoSearchRequest?
     ): TodoPageResponse {
 
         return todoRepository.getPaginatedTodoList(pageNumber, pageSize, sort, request)

--- a/src/test/kotlin/com/umin/todoapp/domain/todo/repository/TodoRepositoryTest.kt
+++ b/src/test/kotlin/com/umin/todoapp/domain/todo/repository/TodoRepositoryTest.kt
@@ -1,0 +1,116 @@
+package com.umin.todoapp.domain.todo.repository
+
+import com.umin.todoapp.domain.config.RepositoryConfig
+import com.umin.todoapp.domain.todo.dto.TodoSearchRequest
+import com.umin.todoapp.domain.todo.model.Todo
+import com.umin.todoapp.domain.user.model.User
+import com.umin.todoapp.domain.user.repository.IUserRepository
+import io.kotest.core.spec.style.ExpectSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestConstructor
+import java.time.OffsetDateTime
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(value = [RepositoryConfig::class])
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@ActiveProfiles("test")
+class TodoRepositoryTest (
+    private val todoRepository: ITodoRepository,
+    private val userRepository: IUserRepository
+) : ExpectSpec({
+    extensions(SpringTestExtension(SpringTestLifecycleMode.Root))
+
+    context("Todo 목록 pagination 조회") {
+        val user1 = User(email = "sample1@naver.com", password = "aaaa", name = "김문어")
+        val user2 = User(email = "sample2@gmail.com", password = "aaaa", name = "김사과")
+        val user3 = User(email = "sample3@daum.net", password = "aaaa", name = "박문어")
+        val userList = listOf(user1, user2, user3)
+        userList.forEach { userRepository.save(it) }
+
+        val todoList = listOf(
+            Todo(title = "투두", description = "a", user = user1, createdAt = OffsetDateTime.now().minusDays(6)),
+            Todo(title = "제목", description = "a", user = user1, createdAt = OffsetDateTime.now().minusDays(5)),
+            Todo(title = "투두", description = "a", user = user1, createdAt = OffsetDateTime.now().minusDays(4), completionStatus = true),
+            Todo(title = "투두", description = "a", user = user2, createdAt = OffsetDateTime.now().minusDays(3)),
+            Todo(title = "제목", description = "a", user = user2, createdAt = OffsetDateTime.now().minusDays(2), completionStatus = true),
+            Todo(title = "투두", description = "a", user = user2, createdAt = OffsetDateTime.now().minusDays(1)),
+            Todo(title = "투두", description = "a", user = user3, createdAt = OffsetDateTime.now().minusHours(20)),
+            Todo(title = "제목", description = "a", user = user3, createdAt = OffsetDateTime.now().minusHours(15), completionStatus = true),
+            Todo(title = "투두", description = "a", user = user3, createdAt = OffsetDateTime.now().minusHours(10)),
+            Todo(title = "제목", description = "a", user = user3, createdAt = OffsetDateTime.now().minusHours(5))
+        )
+        todoList.forEach { todoRepository.save(it) }
+
+        expect("pageNumber와 pageSize에 따른 totalPages와 pageResult를 반환한다") {
+            val actual = todoRepository.getPaginatedTodoList(1, 6, null, null)
+
+            actual.totalPages shouldBe 2
+            actual.pageResult.size shouldBe 6
+        }
+
+        expect("sort에 따라 정렬된 결과를 반환한다") {
+            val actual = todoRepository.getPaginatedTodoList(1, 10, "oldest", null)
+
+            for (i in 1 until actual.pageResult.size) {
+                actual.pageResult[i].createdAt.isBefore(actual.pageResult[i-1].createdAt) shouldBe false
+            }
+        }
+
+        expect("제목에 키워드가 포함된 Todo를 조회한다") {
+            val keyword = "제목"
+            val actual = todoRepository.getPaginatedTodoList(
+                1,
+                10,
+                null,
+                TodoSearchRequest(title = keyword, writer = null, completed = null, daysAgo = null)
+            )
+
+            actual.pageResult.size shouldBe 4
+            actual.pageResult.forEach { it.title.contains(keyword) shouldBe true }
+        }
+
+        expect("작성자에 키워드가 포함된 Todo를 조회한다") {
+            val keyword = "문어"
+            val actual = todoRepository.getPaginatedTodoList(
+                1,
+                10,
+                null,
+                TodoSearchRequest(title = null, writer = keyword, completed = null, daysAgo = null)
+            )
+
+            actual.pageResult.size shouldBe 7
+            actual.pageResult.forEach { it.writer.contains(keyword) shouldBe true }
+        }
+
+        expect("완료 상태가 일치하는 Todo만 조회한다") {
+            val actual = todoRepository.getPaginatedTodoList(
+                1,
+                10,
+                null,
+                TodoSearchRequest(title = null, writer = null, completed = "true", daysAgo = null)
+            )
+
+            actual.pageResult.size shouldBe 3
+            actual.pageResult.forEach { it.completionStatus shouldBe true }
+        }
+
+        expect("N일 안에 작성된 Todo만 조회한다") {
+            val actual = todoRepository.getPaginatedTodoList(
+                1,
+                10,
+                null,
+                TodoSearchRequest(title = null, writer = null, completed = null, daysAgo = "2")
+            )
+
+            actual.pageResult.size shouldBe 6
+        }
+
+    }
+})


### PR DESCRIPTION
## 작업 내용
- TodoSearchRequest nullable 타입으로 변경
- kotest extension 적용
- test DB h2 적용
- Todo Repository - Todo 목록 pagination 조회 테스트
  - pageNumber와 pageSize에 따른 totalPages와 pageResult를 반환
  - sort에 따라 정렬된 결과를 반환
  - 제목에 키워드가 포함된 Todo를 조회
  - 작성자에 키워드가 포함된 Todo를 조회
  - 완료 상태가 일치하는 Todo만 조회
  - N일 안에 작성된 Todo만 조회